### PR TITLE
Add wxcafe & imaginair.es to the list of instances using glitch-soc

### DIFF
--- a/index.md
+++ b/index.md
@@ -20,6 +20,7 @@ You can browse our source code and contribute to the project [on Github][glitch-
 - [monsterpit.net](https://monsterpit.net)
 - [donphan.social](https://donphan.social)
 - [social.wxcafe.net](https://social.wxcafe.net)
+- [imaginair.es](https://imaginair.es)
 
 
 >   (Instance not on the list? Let us know!)

--- a/index.md
+++ b/index.md
@@ -19,6 +19,7 @@ You can browse our source code and contribute to the project [on Github][glitch-
 - [awoo.space](https://awoo.space)
 - [monsterpit.net](https://monsterpit.net)
 - [donphan.social](https://donphan.social)
+- [social.wxcafe.net](https://social.wxcafe.net)
 
 
 >   (Instance not on the list? Let us know!)


### PR DESCRIPTION
social.wxcafe.net is using glitch-soc since 2.2.0

cc @wxcafe